### PR TITLE
RichText - BubbleMenü nicht ausblenden, wenn fokus außerhalb gelegt w…

### DIFF
--- a/.changeset/polite-beers-flash.md
+++ b/.changeset/polite-beers-flash.md
@@ -1,0 +1,5 @@
+---
+"@neuvernetzung/design-system": patch
+---
+
+RichText - BubbleMenü nicht ausblenden, wenn fokus außerhalb gelegt wird, da wenn auf Menü geklickt wird ebenfalls fokus verschwindet #1545

--- a/src/components/ui/RichText/Menus/bubblemenu.tsx
+++ b/src/components/ui/RichText/Menus/bubblemenu.tsx
@@ -107,7 +107,7 @@ export const BubbleMenu = ({ editor, options, plugins }: BubbleMenuProps) => {
     ],
   });
 
-  const openRaw = !editor.view.state.selection.empty && editor.view.hasFocus();
+  const openRaw = !editor.view.state.selection.empty;
 
   const open = useDebounce(openRaw, 250);
 


### PR DESCRIPTION
…ird, da wenn auf Menü geklickt wird ebenfalls fokus verschwindet #1545